### PR TITLE
feat: add error boundary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16938,6 +16938,14 @@
         }
       }
     },
+    "react-error-boundary": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.0.2.tgz",
+      "integrity": "sha512-KVzCusRTFpUYG0OFJbzbdRuxNQOBiGXVCqyNpBXM9z5NFsFLzMjUXMjx8gTja6M6WH+D2PvP3yKz4d8gD1PRaA==",
+      "requires": {
+        "@babel/runtime": "^7.11.2"
+      }
+    },
     "react-error-overlay": {
       "version": "6.0.8",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "@testing-library/user-event": "^12.1.10",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
+        "react-error-boundary": "^3.0.2",
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.0",
         "styled-components": "^5.2.1",

--- a/src/components/ErrorBoundary/ErrorBoundary.stories.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.stories.tsx
@@ -1,0 +1,21 @@
+import React, { FC } from 'react'
+import { ErrorBoundaryProvider } from '.'
+
+const DummyError: FC = () => {
+    throw new Error(
+        'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.'
+    )
+}
+
+export const ErrorBoundaryWithComponent: FC = () => {
+    return (
+        <ErrorBoundaryProvider>
+            <DummyError />
+        </ErrorBoundaryProvider>
+    )
+}
+
+export default {
+    component: ErrorBoundaryWithComponent,
+    title: 'components/ErrorBoundaryComponent',
+}

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -1,0 +1,32 @@
+import React, { ReactElement, ReactNode } from 'react'
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary'
+import { useHistory } from 'react-router-dom'
+import { Button, ErrorFallbackWrapper, Title, Pre } from './styles'
+
+const ErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
+    return (
+        <ErrorFallbackWrapper role="alert">
+            <Title>Something went wrong:</Title>
+            <Pre>{error?.message}</Pre>
+            <Button onClick={resetErrorBoundary}>Go To Home</Button>
+        </ErrorFallbackWrapper>
+    )
+}
+
+export const ErrorBoundaryProvider = ({
+    children,
+}: {
+    children: ReactNode
+}): ReactElement => {
+    const history = useHistory()
+    return (
+        <ErrorBoundary
+            FallbackComponent={ErrorFallback}
+            onReset={() => {
+                history.push('/')
+            }}
+        >
+            {children}
+        </ErrorBoundary>
+    )
+}

--- a/src/components/ErrorBoundary/styles.ts
+++ b/src/components/ErrorBoundary/styles.ts
@@ -1,0 +1,64 @@
+import styled from 'styled-components'
+import { media } from 'theme/media'
+
+// Wrapper
+export const ErrorFallbackWrapper = styled.div`
+    height: calc(100vh - 18rem);
+    width: 80vw;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-evenly;
+    position: relative;
+    left: 50%;
+    transform: translateX(-50%);
+`
+
+// Error Text
+export const Pre = styled.pre`
+    word-wrap: break-word;
+    white-space: pre-wrap;
+    text-align: center;
+    font-family: ${({ theme }) => theme.fonts.Montserrat};
+    color: ${({ theme }) => theme.colors.Red};
+    font-size: 1rem;
+    ${media.phone} {
+        font-size: 2rem;
+    }
+    ${media.tablet} {
+        font-size: 2.5rem;
+    }
+`
+
+export const Title = styled.h1`
+    font-size: 2.5rem;
+    font-family: ${({ theme }) => theme.fonts.Lora};
+    text-align: center;
+    color: ${({ theme }) => theme.colors.Orange};
+    ${media.phone} {
+        font-size: 4rem;
+    }
+    ${media.tablet} {
+        font-size: 6rem;
+    }
+`
+
+export const Button = styled.button`
+    height: 4rem;
+    font-size: 1.6rem;
+    width: 15rem;
+    border: 2px solid ${({ theme }) => theme.colors.Orange};
+    border-radius: 5px;
+    background-color: transparent;
+    color: ${({ theme }) => theme.colors.Orange};
+    transition: all 0.3s;
+    &:hover {
+        background-color: ${({ theme }) => theme.colors.Orange};
+        color: ${({ theme }) => theme.colors.White};
+    }
+    ${media.phone} {
+        font-size: 1.9rem;
+        height: 6rem;
+        width: 20rem;
+    }
+`

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -3,13 +3,16 @@ import { ThemeProvider } from 'styled-components'
 import { BrowserRouter as Router } from 'react-router-dom'
 import { GlobalStyle } from 'theme/globalStyles'
 import { theme } from 'theme/theme'
+import { ErrorBoundaryProvider } from 'components/ErrorBoundary'
 import { YummlyProvider } from './YummlyContext'
 
 export const AppProviders: FC = ({ children }) => (
     <ThemeProvider theme={theme}>
         <GlobalStyle />
-        <Router>
-            <YummlyProvider>{children}</YummlyProvider>
-        </Router>
+        <ErrorBoundaryProvider>
+            <Router>
+                <YummlyProvider>{children}</YummlyProvider>
+            </Router>
+        </ErrorBoundaryProvider>
     </ThemeProvider>
 )

--- a/src/pages/Search/index.tsx
+++ b/src/pages/Search/index.tsx
@@ -88,9 +88,10 @@ export const Search: FC = () => {
                 Accept: 'application/json',
             },
         }
+
         // fetch recipes
-        const response = await window.fetch(url.href, config)
         try {
+            const response = await window.fetch(url.href, config)
             if (response.ok) {
                 // Successful response
                 const successData: SuccessResponse = await response.json()


### PR DESCRIPTION
ErrorBoundary  with a fallback has been added.

Story for ErrorBoundary has been added.

ErrorBoundary is exported as ErrorBoundaryProvider and has been included in the AppProviders.

Fetch in Search has been moved inside of the try catch block.