### PR TITLE
feat(recipes): add prefetched pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, ReactElement } from 'react'
 import { AppProviders } from 'context'
 import { Route, Switch } from 'react-router-dom'
 import { Footer } from 'components/Footer'
@@ -8,11 +8,14 @@ import { Search } from 'pages/Search'
 import { Recipes } from 'pages/Recipes'
 import { NotFound } from 'pages/NotFound'
 import { NoEnvironmentVariables } from 'pages/NoEnvironmentVariables'
+import { Vegan } from 'pages/Vegan'
+import { HighProtein } from 'pages/HighProtein'
+import { LowCarb } from 'pages/LowCarb'
 
 const apiURL = process.env.REACT_APP_API_URL
 const apiKEY = process.env.REACT_APP_API_KEY
 
-const App: FC = () => (
+const App = (): ReactElement => (
   <AppProviders>
     <Navigation />
     {!apiURL && !apiKEY ? (
@@ -21,7 +24,14 @@ const App: FC = () => (
       <Switch>
         <Route exact path="/" component={Home} />
         <Route exact path="/search" component={Search} />
-        <Route exact path="/recipes" component={Recipes} />
+        <Route exact path="/recipes" component={Recipes as FC} />
+        <Route exact path="/recipes/vegan" component={Vegan as FC} />
+        <Route exact path="/recipes/low-carb" component={LowCarb as FC} />
+        <Route
+          exact
+          path="/recipes/high-protein"
+          component={HighProtein as FC}
+        />
         <Route exact path="*" component={NotFound} />
       </Switch>
     )}

--- a/src/components/ErrorBoundary/ErrorBoundary.stories.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.stories.tsx
@@ -1,13 +1,13 @@
-import React, { FC } from 'react'
+import React, { ReactElement } from 'react'
 import { ErrorBoundaryProvider } from '.'
 
-const DummyError: FC = () => {
+const DummyError = () => {
   throw new Error(
     'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.'
   )
 }
 
-export const ErrorBoundaryWithComponent: FC = () => {
+export const ErrorBoundaryWithComponent = (): ReactElement => {
   return (
     <ErrorBoundaryProvider>
       <DummyError />

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,7 +1,7 @@
-import React, { FC } from 'react'
+import React, { ReactElement } from 'react'
 import { HeartIcon, Text, TextLink, FooterWrapper } from './styles'
 
-export const Footer: FC = () => {
+export const Footer = (): ReactElement => {
   return (
     <FooterWrapper>
       <Text>

--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react'
+import React, { ReactElement, useState } from 'react'
 import { CookingSVG } from 'components/SVG/CookingSVG'
 import {
   HamburgerMenuLine,
@@ -12,7 +12,7 @@ import {
   Nav,
 } from './styles'
 
-export const Navigation: FC = () => {
+export const Navigation = (): ReactElement => {
   const [toggleState, setToggleState] = useState(false)
   return (
     <>
@@ -26,9 +26,6 @@ export const Navigation: FC = () => {
         <LinksWrapper isToggled={toggleState}>
           <Link to="/search" onClick={() => setToggleState(false)}>
             Search
-          </Link>
-          <Link to="/recipes/keto" onClick={() => setToggleState(false)}>
-            Ketogenic
           </Link>
           <Link to="/recipes/vegan" onClick={() => setToggleState(false)}>
             Vegan

--- a/src/components/Recipe/Recipe.stories.tsx
+++ b/src/components/Recipe/Recipe.stories.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { ReactElement } from 'react'
 import { RecipesWrapper } from 'pages/Recipes/styles'
 import { recipesData } from 'data'
 import { Recipe as RecipeComponent } from '.'
@@ -8,7 +8,7 @@ export default {
   title: 'components/Recipe',
 }
 
-export const Recipe: FC = () => {
+export const Recipe = (): ReactElement => {
   return (
     <RecipesWrapper>
       {recipesData.map((recipe) => (

--- a/src/components/Spinner/Spinner.stories.tsx
+++ b/src/components/Spinner/Spinner.stories.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { ReactElement } from 'react'
 import { Spinner } from '.'
 
 export default {
@@ -6,6 +6,6 @@ export default {
   title: 'components/Spinner',
 }
 
-export const SpinnerComponent: FC = () => {
+export const SpinnerComponent = (): ReactElement => {
   return <Spinner />
 }

--- a/src/components/Spinner/index.tsx
+++ b/src/components/Spinner/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { ReactElement } from 'react'
 import styled, { keyframes } from 'styled-components'
 import { ReactComponent as LoadingSpinner } from 'assets/spinner.svg'
 
@@ -27,7 +27,7 @@ const StyledSpinner = styled(LoadingSpinner)`
   animation: ${spin} 0.5s linear infinite;
 `
 
-export const Spinner: FC = () => {
+export const Spinner = (): ReactElement => {
   return (
     <Div>
       <StyledSpinner />

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { ReactElement, ReactNode } from 'react'
 import { ThemeProvider } from 'styled-components'
 import { BrowserRouter as Router } from 'react-router-dom'
 import { GlobalStyle } from 'theme/globalStyles'
@@ -6,7 +6,11 @@ import { theme } from 'theme/theme'
 import { ErrorBoundaryProvider } from 'components/ErrorBoundary'
 import { RavenyProvider } from './RavenyContext'
 
-export const AppProviders: FC = ({ children }) => (
+export const AppProviders = ({
+  children,
+}: {
+  children: ReactNode
+}): ReactElement => (
   <ThemeProvider theme={theme}>
     <GlobalStyle />
     <ErrorBoundaryProvider>

--- a/src/pages/HighProtein/index.tsx
+++ b/src/pages/HighProtein/index.tsx
@@ -3,51 +3,36 @@ import { useRavenyContext } from 'context/RavenyContext'
 import { SuccessResponse } from 'types'
 import { Spinner } from 'components/Spinner'
 import { Recipe } from 'components/Recipe'
-import {
-  RecipesWrapper,
-  NoRecipesWrapper,
-  NoRecipesTitle,
-  SadFace,
-  NoRecipesButton,
-} from './styles'
+import { RecipesWrapper } from './styles'
 
-// API Key & ID
+// API Key, ID and URL
+const apiURL = process.env.REACT_APP_API_URL
 const apiKEY = process.env.REACT_APP_API_KEY
 const apiID = process.env.REACT_APP_API_ID
 
-export const Recipes = (): ReactNode => {
+export const HighProtein = (): ReactNode => {
   const { state, dispatch } = useRavenyContext()
 
-  const numbersOfMount = JSON.parse(
-    window.sessionStorage.getItem('recipesMount') as string
-  )
-
-  // URL without key and id
-  const urlToQuery = new URL(
-    JSON.parse(window.sessionStorage.getItem('recipesQueryUrl') as string)
-  )
-
-  // We need to append key and id since they are not included in the URL that gets persisted in sessionStorage
+  const urlToQuery = new URL(apiURL!)
+  // Set query params
   urlToQuery.searchParams.append('app_key', apiKEY!)
   urlToQuery.searchParams.append('app_id', apiID!)
+  urlToQuery.searchParams.append('q', 'chicken')
+  urlToQuery.searchParams.append('diet', 'high-protein')
+  urlToQuery.searchParams.append('from', '0')
+  urlToQuery.searchParams.append('to', '8')
 
   useEffect(() => {
-    // 'recipesMount' in sessionStorage will be 2 after the first render, therefore fetchRecipes will not be fired on the first render
-    window.sessionStorage.setItem('recipesMount', JSON.stringify(2))
-
     const fetchRecipes = async () => {
       dispatch({ type: 'pending' })
 
-      // fetch recipes
       try {
         const response = await window.fetch(urlToQuery.href)
         if (response.ok) {
           // Successful response
           const successData: SuccessResponse = await response.json()
-          window.sessionStorage.setItem('recipesMount', JSON.stringify(1))
           dispatch({
             type: 'recipesResolved',
-            // payload should be an array of recipes
             payload: successData.hits.map((hit) => hit.recipe),
           })
         } else {
@@ -64,27 +49,21 @@ export const Recipes = (): ReactNode => {
         )
       }
     }
-
-    if (numbersOfMount === 2) {
-      fetchRecipes()
-    }
-  }, [dispatch, numbersOfMount, urlToQuery.href])
+    fetchRecipes()
+  }, [dispatch, urlToQuery.href])
 
   if (state.status === 'pending') {
     return <Spinner />
   }
 
-  return state.stateType === 'recipesState' && state.recipes.length > 0 ? (
-    <RecipesWrapper>
-      {state.recipes.map((recipe) => (
-        <Recipe recipe={recipe} key={recipe.uri} />
-      ))}
-    </RecipesWrapper>
-  ) : (
-    <NoRecipesWrapper>
-      <NoRecipesTitle>No Recipes Found!</NoRecipesTitle>
-      <SadFace />
-      <NoRecipesButton to="/search">Back To Search</NoRecipesButton>
-    </NoRecipesWrapper>
+  return (
+    state.stateType === 'recipesState' &&
+    state.recipes.length > 0 && (
+      <RecipesWrapper>
+        {state.recipes.map((recipe) => (
+          <Recipe recipe={recipe} key={recipe.uri} />
+        ))}
+      </RecipesWrapper>
+    )
   )
 }

--- a/src/pages/HighProtein/styles.ts
+++ b/src/pages/HighProtein/styles.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components'
+import { wrapperStyles } from 'styles'
+
+// Recipes
+export const RecipesWrapper = styled.div`
+  ${wrapperStyles}
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+  flex-wrap: wrap;
+  padding: 1rem;
+  gap: 1rem;
+`

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react'
+import React, { ReactElement, useState } from 'react'
 import {
   InfoWrapper,
   HomeWrapper,
@@ -9,7 +9,7 @@ import {
   SearchIcon,
 } from './styles'
 
-export const Home: FC = () => {
+export const Home = (): ReactElement => {
   const [buttonHoverState, setButtonHoverState] = useState(false)
   return (
     <HomeWrapper>

--- a/src/pages/LowCarb/index.tsx
+++ b/src/pages/LowCarb/index.tsx
@@ -3,51 +3,36 @@ import { useRavenyContext } from 'context/RavenyContext'
 import { SuccessResponse } from 'types'
 import { Spinner } from 'components/Spinner'
 import { Recipe } from 'components/Recipe'
-import {
-  RecipesWrapper,
-  NoRecipesWrapper,
-  NoRecipesTitle,
-  SadFace,
-  NoRecipesButton,
-} from './styles'
+import { RecipesWrapper } from './styles'
 
-// API Key & ID
+// API Key, ID and URL
+const apiURL = process.env.REACT_APP_API_URL
 const apiKEY = process.env.REACT_APP_API_KEY
 const apiID = process.env.REACT_APP_API_ID
 
-export const Recipes = (): ReactNode => {
+export const LowCarb = (): ReactNode => {
   const { state, dispatch } = useRavenyContext()
 
-  const numbersOfMount = JSON.parse(
-    window.sessionStorage.getItem('recipesMount') as string
-  )
-
-  // URL without key and id
-  const urlToQuery = new URL(
-    JSON.parse(window.sessionStorage.getItem('recipesQueryUrl') as string)
-  )
-
-  // We need to append key and id since they are not included in the URL that gets persisted in sessionStorage
+  const urlToQuery = new URL(apiURL!)
+  // Set query params
   urlToQuery.searchParams.append('app_key', apiKEY!)
   urlToQuery.searchParams.append('app_id', apiID!)
+  urlToQuery.searchParams.append('q', 'meat')
+  urlToQuery.searchParams.append('diet', 'low-carb')
+  urlToQuery.searchParams.append('from', '0')
+  urlToQuery.searchParams.append('to', '8')
 
   useEffect(() => {
-    // 'recipesMount' in sessionStorage will be 2 after the first render, therefore fetchRecipes will not be fired on the first render
-    window.sessionStorage.setItem('recipesMount', JSON.stringify(2))
-
     const fetchRecipes = async () => {
       dispatch({ type: 'pending' })
 
-      // fetch recipes
       try {
         const response = await window.fetch(urlToQuery.href)
         if (response.ok) {
           // Successful response
           const successData: SuccessResponse = await response.json()
-          window.sessionStorage.setItem('recipesMount', JSON.stringify(1))
           dispatch({
             type: 'recipesResolved',
-            // payload should be an array of recipes
             payload: successData.hits.map((hit) => hit.recipe),
           })
         } else {
@@ -64,27 +49,21 @@ export const Recipes = (): ReactNode => {
         )
       }
     }
-
-    if (numbersOfMount === 2) {
-      fetchRecipes()
-    }
-  }, [dispatch, numbersOfMount, urlToQuery.href])
+    fetchRecipes()
+  }, [dispatch, urlToQuery.href])
 
   if (state.status === 'pending') {
     return <Spinner />
   }
 
-  return state.stateType === 'recipesState' && state.recipes.length > 0 ? (
-    <RecipesWrapper>
-      {state.recipes.map((recipe) => (
-        <Recipe recipe={recipe} key={recipe.uri} />
-      ))}
-    </RecipesWrapper>
-  ) : (
-    <NoRecipesWrapper>
-      <NoRecipesTitle>No Recipes Found!</NoRecipesTitle>
-      <SadFace />
-      <NoRecipesButton to="/search">Back To Search</NoRecipesButton>
-    </NoRecipesWrapper>
+  return (
+    state.stateType === 'recipesState' &&
+    state.recipes.length > 0 && (
+      <RecipesWrapper>
+        {state.recipes.map((recipe) => (
+          <Recipe recipe={recipe} key={recipe.uri} />
+        ))}
+      </RecipesWrapper>
+    )
   )
 }

--- a/src/pages/LowCarb/styles.ts
+++ b/src/pages/LowCarb/styles.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components'
+import { wrapperStyles } from 'styles'
+
+// Recipes
+export const RecipesWrapper = styled.div`
+  ${wrapperStyles}
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+  flex-wrap: wrap;
+  padding: 1rem;
+  gap: 1rem;
+`

--- a/src/pages/NoEnvironmentVariables/NoEnvironmentVariables.stories.tsx
+++ b/src/pages/NoEnvironmentVariables/NoEnvironmentVariables.stories.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { ReactElement } from 'react'
 import { NoEnvironmentVariables } from '.'
 
 export default {
@@ -6,6 +6,6 @@ export default {
   title: 'pages/NoEnvironmentVariables',
 }
 
-export const NoEnvironmentVariablesPage: FC = () => {
+export const NoEnvironmentVariablesPage = (): ReactElement => {
   return <NoEnvironmentVariables />
 }

--- a/src/pages/NoEnvironmentVariables/index.tsx
+++ b/src/pages/NoEnvironmentVariables/index.tsx
@@ -1,7 +1,7 @@
-import React, { FC } from 'react'
+import React, { ReactElement } from 'react'
 import { DocLink, FileSpan, NoEnvVarWrapper, Text, TextWrapper } from './styles'
 
-export const NoEnvironmentVariables: FC = () => {
+export const NoEnvironmentVariables = (): ReactElement => {
   return (
     <NoEnvVarWrapper>
       <TextWrapper>

--- a/src/pages/NotFound/NotFound.stories.tsx
+++ b/src/pages/NotFound/NotFound.stories.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { ReactElement } from 'react'
 import { NotFound } from '.'
 
 export default {
@@ -6,6 +6,6 @@ export default {
   title: 'pages/NotFound',
 }
 
-export const NotFoundPage: FC = () => {
+export const NotFoundPage = (): ReactElement => {
   return <NotFound />
 }

--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -1,7 +1,7 @@
-import React, { FC } from 'react'
+import React, { ReactElement } from 'react'
 import { NotFoundWrapper, NotFoundSVG } from './styles'
 
-export const NotFound: FC = () => {
+export const NotFound = (): ReactElement => {
   return (
     <NotFoundWrapper>
       <NotFoundSVG />

--- a/src/pages/Search/index.tsx
+++ b/src/pages/Search/index.tsx
@@ -1,4 +1,10 @@
-import React, { ChangeEvent, FC, FormEvent, useEffect, useState } from 'react'
+import React, {
+  ChangeEvent,
+  FormEvent,
+  ReactElement,
+  useEffect,
+  useState,
+} from 'react'
 import { useHistory } from 'react-router-dom'
 import { useRavenyContext } from 'context/RavenyContext'
 import { Spinner } from 'components/Spinner'
@@ -27,7 +33,7 @@ type SearchState = {
   searchValue: string
 }
 
-export const Search: FC = () => {
+export const Search = (): ReactElement => {
   const [focusState, setFocusState] = useState(false)
   const [isMobile, setIsMobile] = useState(false)
   const [isErrorCharacters, setIsErrorCharacters] = useState(false)
@@ -94,7 +100,6 @@ export const Search: FC = () => {
 
         dispatch({
           type: 'recipesResolved',
-          // payload should be an array of recipes
           payload: successData.hits.map((hit) => hit.recipe),
         })
 

--- a/src/pages/Vegan/styles.ts
+++ b/src/pages/Vegan/styles.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components'
+import { wrapperStyles } from 'styles'
+
+// Recipes
+export const RecipesWrapper = styled.div`
+  ${wrapperStyles}
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+  flex-wrap: wrap;
+  padding: 1rem;
+  gap: 1rem;
+`


### PR DESCRIPTION
Pages vegan, high-protein and low-carb have been added and they fetch the relevant recipes.

Components that used FC as type, has been converted over to Components that just return ReactElement, since FC should be avoided, which can also be found in this issue: https://github.com/facebook/create-react-app/pull/8177#issue-353062710