### PR TITLE
feat(search): add proper validation when excluding ingredients

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,6 +35,7 @@
         "devDependencies": true
       }
     ],
+    "no-nested-ternary": 0,
     "@typescript-eslint/no-non-null-assertion": 0,
     "react/react-in-jsx-scope": 0,
     "@typescript-eslint/explicit-module-boundary-types": 0,


### PR DESCRIPTION
A Capitalize util function has been created.

User can now exclude ingredients by clicking enter.

Excluding ingredients can now be two different messages, one if the ingredient has already been excluded, and the other if characters are too few.