### PR TITLE
feat(InfiniteScrolling): implement infinite scrolling

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,6 +36,7 @@
       }
     ],
     "no-nested-ternary": 0,
+    "no-plusplus": 0,
     "@typescript-eslint/no-non-null-assertion": 0,
     "react/react-in-jsx-scope": 0,
     "@typescript-eslint/explicit-module-boundary-types": 0,

--- a/src/components/Recipe/RecipePages.stories.tsx
+++ b/src/components/Recipe/RecipePages.stories.tsx
@@ -1,5 +1,5 @@
 import { recipesData } from 'data'
-import { Spinner } from 'components/Spinner/index'
+import { LoadMoreSpinner } from 'components/Spinner'
 import {
   RecipesMain,
   RecipesSection,
@@ -33,7 +33,7 @@ export const RecipesPageWithLoadMoreSpinner = () => (
       ))}
     </RecipesSection>
     <LoadMoreSpinnerSection>
-      <Spinner isLoadMoreSpinner />
+      <LoadMoreSpinner />
     </LoadMoreSpinnerSection>
   </RecipesMain>
 )

--- a/src/components/Recipe/styles.ts
+++ b/src/components/Recipe/styles.ts
@@ -48,6 +48,14 @@ export const LoadMoreSpinnerSection = styled.section`
   height: 10rem;
 `
 
+export const IntersectingElementToLoadMore = styled.div`
+  grid-area: spinner;
+  background-color: transparent;
+  visibility: hidden;
+  width: 100%;
+  height: 3.5rem;
+`
+
 /* Styles for Recipe Component */
 export const RecipeWrapperLink = styled(Link)`
   text-decoration: none;

--- a/src/components/Spinner/index.tsx
+++ b/src/components/Spinner/index.tsx
@@ -16,24 +16,30 @@ const spin = keyframes`
     }
 `
 
-export const Spinner = styled(LoadingSpinner)<{ isLoadMoreSpinner?: boolean }>`
+const spinnerStyles = css`
   position: absolute;
-  transform: translate(-50%, -50%);
-  top: 30%;
   left: 50%;
+  transform: translate(-50%, -50%);
   fill: ${({ theme }) => theme.colors.Orange};
   height: 20%;
   animation: ${spin} 0.5s linear infinite;
-  ${(props) =>
-    props.isLoadMoreSpinner &&
-    css`
-      top: 50%;
-      height: 50%;
-    `}
+`
+
+export const FullPage = styled(LoadingSpinner)`
+  ${spinnerStyles}
+  top: 30%;
+`
+
+export const LoadMore = styled(LoadingSpinner)`
+  ${spinnerStyles}
+  top: 50%;
+  height: 70%;
 `
 
 export const FullPageSpinner = () => (
   <Main>
-    <Spinner aria-label="loading" />
+    <FullPage aria-label="loading" />
   </Main>
 )
+
+export const LoadMoreSpinner = () => <LoadMore aria-label="loading" />

--- a/src/context/RavenyContext.tsx
+++ b/src/context/RavenyContext.tsx
@@ -29,8 +29,9 @@ interface SingleRecipeState {
 
 /** Recipes State */
 interface RecipesState {
-  status: 'resolved'
+  status: 'resolved' | 'loadingMore'
   recipes: Recipe[]
+  hasMoreRecipes: boolean
   results: number
   stateType: 'recipesState'
 }
@@ -50,11 +51,19 @@ type RavenyState =
   | RecipesState
   | ErrorState
 
-/** Action Type */
+/* Action Type */
 export type Action =
   | { type: 'loading' }
   | { type: 'singleRecipeResolved'; payload: Recipe }
-  | { type: 'recipesResolved'; payload: { results: number; recipes: Recipe[] } }
+  | {
+      type: 'recipesResolved'
+      payload: { results: number; recipes: Recipe[]; more: boolean }
+    }
+  | {
+      type: 'moreRecipesResolved'
+      payload: { recipes: Recipe[]; more: boolean }
+    }
+  | { type: 'loadingMoreRecipes' }
   | { type: 'rejected'; payload: string }
 
 const initialState: RavenyState = {
@@ -79,10 +88,25 @@ const ravenyReducer = (state: RavenyState, action: Action): RavenyState => {
     case 'recipesResolved':
       return {
         status: 'resolved',
-        recipes: action.payload.recipes,
         results: action.payload.results,
+        recipes: action.payload.recipes,
+        hasMoreRecipes: action.payload.more,
         stateType: 'recipesState',
       }
+    case 'loadingMoreRecipes':
+      return {
+        ...state,
+        status: 'loadingMore',
+        stateType: 'recipesState',
+      } as RecipesState
+    case 'moreRecipesResolved':
+      return {
+        ...state,
+        status: 'resolved',
+        recipes: [...action.payload.recipes],
+        stateType: 'recipesState',
+        hasMoreRecipes: action.payload.more,
+      } as RecipesState
     case 'rejected':
       return {
         status: 'rejected',

--- a/src/hooks/useOnInfinite.ts
+++ b/src/hooks/useOnInfinite.ts
@@ -1,0 +1,27 @@
+import { useRavenyDispatch } from 'context/RavenyContext'
+import { useEffect, useRef } from 'react'
+import { client } from 'utils/client'
+
+export const useOnInfinite = (href: string, isVisible: boolean) => {
+  const { dispatch } = useRavenyDispatch()
+  const moreRecipesFetchedTimesRef = useRef(1)
+  useEffect(() => {
+    client({
+      dispatch,
+      href,
+      shouldFetchMultipleRecipes: true,
+    })
+  }, [dispatch, href])
+
+  useEffect(() => {
+    if (isVisible) {
+      client({
+        dispatch,
+        href,
+        shouldFetchMoreRecipes: true,
+        moreRecipesFetchedTimes: moreRecipesFetchedTimesRef.current,
+      })
+      moreRecipesFetchedTimesRef.current++
+    }
+  }, [isVisible, dispatch, href])
+}

--- a/src/pages/LowCarb/index.tsx
+++ b/src/pages/LowCarb/index.tsx
@@ -1,20 +1,22 @@
-import { useEffect } from 'react'
-import { useRavenyDispatch, useRavenyState } from 'context/RavenyContext'
-import { client } from 'utils/client'
+import { v4 as uuidv4 } from 'uuid'
+import { useRavenyState } from 'context/RavenyContext'
 import { Recipe } from 'components/Recipe'
 import {
   RecipesMain,
   RecipesHeading,
   RecipesSection,
+  LoadMoreSpinnerSection,
+  IntersectingElementToLoadMore,
 } from 'components/Recipe/styles'
-import { FullPageSpinner } from 'components/Spinner'
+import { FullPageSpinner, LoadMoreSpinner } from 'components/Spinner'
+import { useOnScreen } from 'hooks/useOnScreen'
+import { useOnInfinite } from 'hooks/useOnInfinite'
 
 /* URL */
 const apiURL = process.env.REACT_APP_API_URL
 
 export const LowCarb = () => {
   const { state } = useRavenyState()
-  const { dispatch } = useRavenyDispatch()
 
   const urlObject = new URL(apiURL!)
 
@@ -24,13 +26,11 @@ export const LowCarb = () => {
 
   const { href } = urlObject
 
-  useEffect(() => {
-    client({
-      dispatch,
-      href,
-      shouldFetchMultipleRecipes: true,
-    })
-  }, [dispatch, href])
+  const { isVisible, setIntersectingElement } = useOnScreen({
+    threshold: 1,
+  })
+
+  useOnInfinite(href, isVisible)
 
   if (state.status === 'loading') {
     return <FullPageSpinner />
@@ -38,12 +38,19 @@ export const LowCarb = () => {
 
   return state.stateType === 'recipesState' && state.recipes.length > 0 ? (
     <RecipesMain>
-      <RecipesHeading>Low Carb</RecipesHeading>
+      <RecipesHeading>Vegan</RecipesHeading>
       <RecipesSection>
         {state.recipes.map((recipe) => (
-          <Recipe recipe={recipe} key={recipe.uri} />
+          <Recipe recipe={recipe} key={uuidv4()} />
         ))}
       </RecipesSection>
+      {state.status === 'loadingMore' ? (
+        <LoadMoreSpinnerSection>
+          <LoadMoreSpinner />
+        </LoadMoreSpinnerSection>
+      ) : state.hasMoreRecipes ? (
+        <IntersectingElementToLoadMore ref={setIntersectingElement} />
+      ) : null}
     </RecipesMain>
   ) : null
 }

--- a/src/pages/Search/index.tsx
+++ b/src/pages/Search/index.tsx
@@ -200,7 +200,6 @@ export const Search = () => {
   }
 
   useEffect(() => {
-    window.sessionStorage.clear()
     /* Short Title in Mobile View */
     const setIsMobileView = () => {
       setIsMobile(window.matchMedia('(max-width: 768px)').matches)

--- a/src/pages/Vegan/index.tsx
+++ b/src/pages/Vegan/index.tsx
@@ -1,20 +1,22 @@
-import { useEffect } from 'react'
-import { useRavenyDispatch, useRavenyState } from 'context/RavenyContext'
-import { client } from 'utils/client'
+import { useRavenyState } from 'context/RavenyContext'
+import { v4 as uuidv4 } from 'uuid'
 import { Recipe } from 'components/Recipe'
 import {
+  IntersectingElementToLoadMore,
+  LoadMoreSpinnerSection,
   RecipesHeading,
   RecipesMain,
   RecipesSection,
 } from 'components/Recipe/styles'
-import { FullPageSpinner } from 'components/Spinner'
+import { FullPageSpinner, LoadMoreSpinner } from 'components/Spinner'
+import { useOnScreen } from 'hooks/useOnScreen'
+import { useOnInfinite } from 'hooks/useOnInfinite'
 
 /* URL */
 const apiURL = process.env.REACT_APP_API_URL
 
 export const Vegan = () => {
   const { state } = useRavenyState()
-  const { dispatch } = useRavenyDispatch()
 
   const urlObject = new URL(apiURL!)
 
@@ -24,13 +26,11 @@ export const Vegan = () => {
 
   const { href } = urlObject
 
-  useEffect(() => {
-    client({
-      dispatch,
-      href,
-      shouldFetchMultipleRecipes: true,
-    })
-  }, [dispatch, href])
+  const { isVisible, setIntersectingElement } = useOnScreen({
+    threshold: 1,
+  })
+
+  useOnInfinite(href, isVisible)
 
   if (state.status === 'loading') {
     return <FullPageSpinner />
@@ -41,9 +41,16 @@ export const Vegan = () => {
       <RecipesHeading>Vegan</RecipesHeading>
       <RecipesSection>
         {state.recipes.map((recipe) => (
-          <Recipe recipe={recipe} key={recipe.uri} />
+          <Recipe recipe={recipe} key={uuidv4()} />
         ))}
       </RecipesSection>
+      {state.status === 'loadingMore' ? (
+        <LoadMoreSpinnerSection>
+          <LoadMoreSpinner />
+        </LoadMoreSpinnerSection>
+      ) : state.hasMoreRecipes ? (
+        <IntersectingElementToLoadMore ref={setIntersectingElement} />
+      ) : null}
     </RecipesMain>
   ) : null
 }

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -55,7 +55,7 @@ export const client = async ({
         })
 
         /* Should Redirect to Route */
-        if (shouldRedirect && redirectRoute !== undefined) {
+        if (shouldRedirect) {
           history.push(redirectRoute)
         }
       } else {

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -12,57 +12,100 @@ export const client = async ({
   history = {} as History,
   href = '',
   redirectRoute = '',
+  moreRecipesFetchedTimes = 1,
   shouldUseSessionStorage = false,
   shouldRedirect = false,
   shouldFetchMultipleRecipes = false,
+  shouldFetchMoreRecipes = false,
 } = {}) => {
-  dispatch({ type: 'loading' })
+  if (shouldFetchMultipleRecipes) {
+    dispatch({ type: 'loading' })
+    try {
+      const urlObject = new URL(href)
 
-  try {
-    const urlObject = new URL(href)
-    urlObject.searchParams.append('app_key', apiKEY!)
-    urlObject.searchParams.append('app_id', apiID!)
-    urlObject.searchParams.append('from', '0')
-    urlObject.searchParams.append('to', '8')
+      /* Query Params */
+      urlObject.searchParams.append('app_key', apiKEY!)
+      urlObject.searchParams.append('app_id', apiID!)
+      urlObject.searchParams.append('from', '0')
+      urlObject.searchParams.append('to', '8')
 
-    const { href: url } = urlObject
+      const { href: url } = urlObject
 
-    const response = await window.fetch(url)
-    if (response.ok) {
-      const successData: SuccessResponse = await response.json()
+      /* Fetch */
+      const response = await fetch(url)
+      if (response.ok) {
+        const { count, hits, more }: SuccessResponse = await response.json()
 
-      /* Persist URL in Session Storage */
-      if (shouldUseSessionStorage) {
-        const urlToSessionStorage = new URL(href)
-        window.sessionStorage.setItem(
-          'recipesQueryUrl',
-          JSON.stringify(urlToSessionStorage.href)
-        )
-      }
-
-      /* Multiple Recipes */
-      if (shouldFetchMultipleRecipes) {
+        /* Persist URL in Session Storage */
+        if (shouldUseSessionStorage) {
+          window.sessionStorage.clear()
+          const urlToSessionStorage = new URL(href)
+          sessionStorage.setItem(
+            'recipesQueryUrl',
+            JSON.stringify(urlToSessionStorage.href)
+          )
+        }
         dispatch({
           type: 'recipesResolved',
           payload: {
-            results: successData.count,
-            recipes: successData.hits.map((hit) => hit.recipe),
+            results: count,
+            recipes: hits.map((hit) => hit.recipe),
+            more,
           },
         })
-      }
 
-      /* Should Redirect to Route */
-      if (shouldRedirect && redirectRoute !== undefined) {
-        history.push(redirectRoute)
+        /* Should Redirect to Route */
+        if (shouldRedirect && redirectRoute !== undefined) {
+          history.push(redirectRoute)
+        }
+      } else {
+        const failureData = await response.json()
+        dispatch({ type: 'rejected', payload: failureData.message })
+        throw new Error(
+          `Something went wrong with the request, message: ${failureData.message}`
+        )
       }
-    } else {
-      const failureData = await response.json()
-      dispatch({ type: 'rejected', payload: failureData.message })
+    } catch (error) {
       throw new Error(
-        `Something went wrong with the request, message: ${failureData.message}`
+        `Something went terribly wrong! Message: ${error.message}`
       )
     }
-  } catch (error) {
-    throw new Error(`Something went terribly wrong! Message: ${error.message}`)
+  } else if (shouldFetchMoreRecipes) {
+    dispatch({ type: 'loadingMoreRecipes' })
+    try {
+      const urlObject = new URL(href)
+      const from = 0
+      const to = 16
+
+      /* Query Params */
+      urlObject.searchParams.append('app_key', apiKEY!)
+      urlObject.searchParams.append('app_id', apiID!)
+      urlObject.searchParams.append(
+        'from',
+        String(from * moreRecipesFetchedTimes)
+      )
+      urlObject.searchParams.append('to', String(to * moreRecipesFetchedTimes))
+      const { href: url } = urlObject
+
+      /* Fetch */
+      const response = await fetch(url)
+      if (response.ok) {
+        const { hits, more }: SuccessResponse = await response.json()
+        dispatch({
+          type: 'moreRecipesResolved',
+          payload: { recipes: hits.map((hit) => hit.recipe), more },
+        })
+      } else {
+        const failureData = await response.json()
+        dispatch({ type: 'rejected', payload: failureData.message })
+        throw new Error(
+          `Something went wrong with the request, message: ${failureData.message}`
+        )
+      }
+    } catch (error) {
+      throw new Error(
+        `Something went terribly wrong! Message: ${error.message}`
+      )
+    }
   }
 }


### PR DESCRIPTION
Infinite Scrolling has been implemented for all pages with recipes.

Eslint rule plus-plus has been disabled, only causes harm.

Spinner has been divided into two different types, one for loading more recipes and one which is for the full page.

Context has been updated to be able to track, whether more recipes exist & add more recipes during infinite scroll.

A custom hooks has been implemented as an abstraction for the infinite scrolling for three pages which had the same logic.

Client Util now has an if else statement to check whether we want to fetch more recipes or if it is the initial fetch.