### PR TITLE
feat: general cleanup

### DIFF
--- a/src/pages/Search/index.tsx
+++ b/src/pages/Search/index.tsx
@@ -95,7 +95,7 @@ export const Search = () => {
   const { state } = useRavenyState()
   const history = useHistory()
 
-  const handleCaloriesChange = (event: ChangeEvent<HTMLInputElement>): void => {
+  const handleCaloriesChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (event.target.validity.valid) {
       setSearchState({
         ...searchState,
@@ -104,7 +104,7 @@ export const Search = () => {
     }
   }
 
-  const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setSearchState({
       ...searchState,
       [event.target.name]: event.target.value,
@@ -165,7 +165,7 @@ export const Search = () => {
     }
   }
 
-  const onSubmit = (event: FormEvent): void | number => {
+  const onSubmit = (event: FormEvent) => {
     event.preventDefault()
     if (validateInputOnSubmit() === true) {
       urlToQuery.searchParams.append('q', searchValue.toLowerCase())

--- a/src/theme/media.ts
+++ b/src/theme/media.ts
@@ -1,4 +1,4 @@
-const customMediaQuery = (maxWidth: number): string =>
+const customMediaQuery = (maxWidth: number) =>
   `@media (min-width: ${maxWidth}px)`
 
 export const media = {

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -1,4 +1,3 @@
-/* Types */
 type Measure = {
   uri: string
   label: string
@@ -51,7 +50,6 @@ export enum HealthLabel {
   'shellfish-free' = 'shellfish-free',
 }
 
-/* Recipe Type */
 export type Recipe = {
   uri: string
   label: string
@@ -70,7 +68,6 @@ export type Recipe = {
   healthLabels: HealthLabel[]
 }
 
-/* Response Types */
 type Hit = {
   recipe: Recipe
   bookmarked: boolean

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -1,9 +1,11 @@
 import faker from 'faker'
 import { DietLabel, HealthLabel } from 'types'
 
-export const getRandomLabel = <T extends typeof DietLabel | typeof HealthLabel>(
-  enumLabel: T
-): T[keyof T] => faker.random.arrayElement(Object.values(enumLabel))
+export const getRandomLabel = <
+  Label extends typeof DietLabel | typeof HealthLabel
+>(
+  enumLabel: Label
+): Label[keyof Label] => faker.random.arrayElement(Object.values(enumLabel))
 
 export const persistUrlInSessionStorage = (url: string) => {
   window.sessionStorage.clear()


### PR DESCRIPTION
Remove type annotations of what a function returns since it is not needed.

Rename generic in `getRandomLabel` function.

Remove unnecessary comments.